### PR TITLE
bump click dependency up to a minimum of 8.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ install_requires = [
     "arrow==0.17.0",
     "cassandra-driver==3.*",
     "cassandra-migrate==0.3.5",
-    "click>=7.1.2,<9.0.0",
+    "click==8.*",
     "future",
     "geomet",
     "python-dateutil==2.*",


### PR DESCRIPTION
click 7.x has a CVE which has been flagged on some of our internal repos that pull it in through the chain starting at `cassandra-migrate`

the change that James had already made here would probably fix that _on a clean install_ - but if we know we want 8.x, it seems to me that we should require 8.x!